### PR TITLE
Remove some unused code in ConfigUtils.ts

### DIFF
--- a/src/ConfigUtils.ts
+++ b/src/ConfigUtils.ts
@@ -70,13 +70,6 @@ export class ConfigUtils {
     }
 
     public static getDebugConfig(): CppDebugConfig[] | undefined {
-        let debugConfigNames = workspace.getConfiguration("gtest-adapter").get<string | string[]>("debugConfig");
-        if (!debugConfigNames) {
-            return undefined;
-        }
-        if (! Array.isArray(debugConfigNames)) {
-            debugConfigNames = [debugConfigNames];
-        }
         const namesSet = ConfigUtils.getConfigs();
         if (!namesSet) {
             return undefined;


### PR DESCRIPTION
The removed code is a duplicate of getConfigs(), maybe it was accidentally left there during a refactoring?